### PR TITLE
Add extra close handler for credits modal

### DIFF
--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -4,7 +4,7 @@
       <header class="flex justify-between mb-8">
         <h2 id="modal-credits-title" class="my-0">Credits</h2>
         <button aria-label="Close modal" data-micromodal-close class="text-white relative right-0">
-          <img src="{{ '/assets/images/icons/cross.svg' | relative_url }}">
+          <img src="{{ '/assets/images/icons/cross.svg' | relative_url }}" data-micromodal-close>
         </button>
       </header>
       <div id="modal-credits-content" class="md:mr-24">


### PR DESCRIPTION
It looks like we have to add `data-micromodal-close` on _every_ element that needs to get the onclick handler. I guess the `<img>` click event doesn't bubble up to the button? 🤷
